### PR TITLE
hex conversion for shorter hex codes working

### DIFF
--- a/assets/js/Components/Forms/ContrastForm.js
+++ b/assets/js/Components/Forms/ContrastForm.js
@@ -206,7 +206,7 @@ export default class ContrastForm extends React.Component {
             value={this.state.backgroundColor}
             onChange={this.handleInputBackground}
             renderBeforeInput={
-              <span style={{ boxShadow: '0 0 5px 0 #CCC', backgroundColor: this.state.backgroundColor, width: '20px', height: '20px', opacity: 1.0, display: 'inline-block' }}></span>
+              <span style={{ boxShadow: '0 0 5px 0 #CCC', backgroundColor: Contrast.convertShortenedHex(this.state.backgroundColor), width: '20px', height: '20px', opacity: 1.0, display: 'inline-block' }}></span>
             }
             renderAfterInput={
               <View>
@@ -237,7 +237,7 @@ export default class ContrastForm extends React.Component {
             onChange={this.handleInputText}
             messages={this.state.textInputErrors}
             renderBeforeInput={
-              <div style={{ boxShadow: '0 0 5px 0 #CCC', backgroundColor: this.state.textColor, width: '20px', height: '20px', opacity: 1.0 }}></div>
+              <div style={{ boxShadow: '0 0 5px 0 #CCC', backgroundColor: Contrast.convertShortenedHex(this.state.textColor), width: '20px', height: '20px', opacity: 1.0 }}></div>
             }
             renderAfterInput={
               <View>
@@ -314,8 +314,8 @@ export default class ContrastForm extends React.Component {
   processHtml(html) {
     let element = Html.toElement(html)
 
-    element.style.backgroundColor = this.state.backgroundColor
-    element.style.color = this.state.textColor
+    element.style.backgroundColor = Contrast.convertShortenedHex(this.state.backgroundColor)
+    element.style.color = Contrast.convertShortenedHex(this.state.textColor)
 
     element.style.fontWeight = (this.state.useBold) ? "bold" : "normal"
     element.style.fontStyle = (this.state.useItalics) ? "italic" : "normal"

--- a/assets/js/Services/Contrast.js
+++ b/assets/js/Services/Contrast.js
@@ -208,17 +208,23 @@ class Contrast {
   convertShortenedHex(color) {
     color = color.substring(1);
 
-    if (color.length == 3) {
-      color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
+    // If the string is too long, cut it off at 6 characters
+    if(color.length > 6) {
+      color = color.substring(0,6)
     } 
-    
-    if (color.length == 4 || color.length == 5) {
+    // If the length is 3, hex shorthand is being used
+    else if (color.length == 3) {
+      color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
+    }
+    // If the length is not 3 or 6, pad the end with zeroes
+    else if(color.length != 6) {
       let padding = '0'.repeat(6 - color.length)
       color = color + padding;
     }
 
     return '#' + color
   }
+
 }
 
 export default new Contrast()

--- a/assets/js/Services/Contrast.js
+++ b/assets/js/Services/Contrast.js
@@ -194,18 +194,30 @@ class Contrast {
   }
 
   parseRgb(color) {
+    color = this.convertShortenedHex(color)
     color = color.substring(1);
-    if (color.length == 3) {
-      color = color + color;
-    }
-
+    
     var hex = parseInt(color.toUpperCase(), 16);
-
 
     var r = hex >> 16;
     var g = hex >> 8 & 0xFF;
     var b = hex & 0xFF;
     return [r, g, b];
+  }
+
+  convertShortenedHex(color) {
+    color = color.substring(1);
+
+    if (color.length == 3) {
+      color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
+    } 
+    
+    if (color.length == 4 || color.length == 5) {
+      let padding = '0'.repeat(6 - color.length)
+      color = color + padding;
+    }
+
+    return '#' + color
   }
 }
 


### PR DESCRIPTION
Contrast Form now:

- Properly handles 3 character hex shorthand
- Appends 0's to the end of hex strings shorter than 6 characters (except for 3)
- Cuts off hex strings longer than 6 characters 