### PR TITLE
Change settings to include defaultTerm and make defaultTerm be set in Admin

### DIFF
--- a/assets/js/Components/Admin/AdminApp.js
+++ b/assets/js/Components/Admin/AdminApp.js
@@ -26,18 +26,13 @@ class AdminApp extends React.Component {
         const accountIds = Object.keys(this.settings.accounts)
         this.settings.accountId = accountIds.shift()
       }
-      if(this.settings.terms) {
-        const termIds = Object.keys(this.settings.terms)
-        termIds.sort()
-        this.settings.termId = termIds.shift()
-      }
     }
     
     this.state = {
       courses: {},
       filters: {
         accountId: this.settings.accountId,
-        termId: this.settings.termId,
+        termId: this.settings.defaultTerm,
         includeSubaccounts: true,
       },
       accountData: [],

--- a/src/Lms/Canvas/CanvasLms.php
+++ b/src/Lms/Canvas/CanvasLms.php
@@ -460,7 +460,7 @@ class CanvasLms implements LmsInterface {
         
         if (isset($content['enrollment_terms'])) {
             foreach ($content['enrollment_terms'] as $term) {
-                $terms[$term['id']] = $term['name'];
+                $terms[$term['id']] = $term;
             }
         }
 


### PR DESCRIPTION
Change settings to include a defaultTerm ID to be able to pass it through as the default in the admin side instead of just defaulting to the first item in the list. 