### PR TITLE
Fix Missing Course LMS Course ID by passing in State to Oauth

### DIFF
--- a/src/Lms/Canvas/CanvasLms.php
+++ b/src/Lms/Canvas/CanvasLms.php
@@ -100,11 +100,13 @@ class CanvasLms implements LmsInterface {
 
     public function getOauthUri(Institution $institution)
     {
+        $session = $this->sessionService->getSession();
         $query = [
             'client_id' => $institution->getApiClientId(),
             'scope' => $this->getScopes(),
             'response_type' => 'code',
             'redirect_uri' => LmsUserService::getOauthRedirectUri(),
+            'state' => $session->getUuid()
         ];
         $baseUrl = $institution->getLmsDomain();
 

--- a/src/Services/SessionService.php
+++ b/src/Services/SessionService.php
@@ -49,7 +49,12 @@ class SessionService {
         // Check PHP session for a UUID
         if (!$uuid) {
             $uuid = $this->request->cookies->get('AUTH_TOKEN');
-        }        
+        }
+        
+        // Check state for UUID from Oauth
+        if (!$uuid) {
+            $uuid = $this->request->query->get('state');
+        }
 
         if ($uuid) {
             $this->userSession = $this->sessionRepo->findOneBy(['uuid' => $uuid]);


### PR DESCRIPTION
Fix Missing Course LMS Course ID by Passing in state to Oauth and grabbing it back out from getSession as a last chance before creating a session.